### PR TITLE
bugfix: emit members even for already accessed users

### DIFF
--- a/socket.js
+++ b/socket.js
@@ -14,9 +14,9 @@ module.exports = io => {
         if (!accessors.includes(user)) {
             accessors.push(user)
             socket.broadcast.emit('enter', user) // 전체 유저에게 누가 들어왔는지 보내줌
-            socket.emit('members', accessors)
         }
 
+        socket.emit('members', accessors)
         io.to(socket.id).emit('name', user) // 접속한 유저에게 랜덤으로 추출된 이름을 보내줌
 
         socket.on('disconnect', () => {


### PR DESCRIPTION
Previously, accessors were sent to users only on their first access.
But since accessors list is needed for every socket connection,
send accessors even for already accessed users