### PR TITLE
feat: eslint ignore variables starting with underscore

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -13,6 +13,13 @@
     ],
     "rules": {
         "prettier/prettier": 2,
-        "no-empty": ["error", { "allowEmptyCatch": true  }]
+        "no-empty": ["error", { "allowEmptyCatch": true  }],
+        "no-unused-vars": [
+          "error",
+          {
+            "args": "all",
+            "argsIgnorePattern": "^_"
+          }
+        ]
     }
 }


### PR DESCRIPTION
This PR adds an eslint rule to ignore variables starting with an underscore (e.g. `_`, `_foo`)