### PR TITLE
Feature/block duplicate votes

### DIFF
--- a/models/vote.js
+++ b/models/vote.js
@@ -24,10 +24,13 @@ const voteSchema = mongoose.Schema(
         },
         submissions: {
             type: [
-                {
-                    username: String,
-                    choice: String
-                }
+                mongoose.Schema(
+                    {
+                        username: String,
+                        choice: String
+                    },
+                    { _id: false }
+                )
             ],
             default: []
         }

--- a/routes/votes.js
+++ b/routes/votes.js
@@ -77,10 +77,8 @@ router.put('/:id', async (req, res) => {
         });
     });
 
-    if (result)
-        res.json({
-            success: true
-        });
+    if (result) res.json({ success: true });
+    else res.json({ success: false });
 });
 
 export default router;

--- a/routes/votes.js
+++ b/routes/votes.js
@@ -5,9 +5,51 @@ const router = express.Router();
 
 // GET /api/votes
 router.get('/', async (req, res) => {
-    const votes = await Vote.find({})
-        .sort({ expires: -1 })
-        .catch(err => console.error(err));
+    const { sparcs_id } = req.decoded;
+
+    const votes = await Vote.aggregate([
+        {
+            $sort: {
+                expires: -1
+            }
+        },
+        {
+            $addFields: {
+                userVoteStatus: {
+                    $reduce: {
+                        input: '$submissions',
+                        initialValue: { hasAlreadyVoted: false, choice: null },
+                        in: {
+                            $cond: {
+                                if: {
+                                    $or: [
+                                        '$$value.hasAlreadyVoted',
+                                        { $ne: ['$$this.username', sparcs_id] }
+                                    ]
+                                },
+                                then: '$$value',
+                                else: {
+                                    hasAlreadyVoted: true,
+                                    choice: '$$this.choice'
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        {
+            $project: {
+                hasAlreadyVoted: '$userVoteStatus.hasAlreadyVoted',
+                userChoice: '$userVoteStatus.choice',
+                choices: 1,
+                title: 1,
+                content: 1,
+                subtitle: 1,
+                expires: 1
+            }
+        }
+    ]).catch(err => console.error(err));
 
     res.json({ votes });
 });

--- a/routes/votes.js
+++ b/routes/votes.js
@@ -68,7 +68,8 @@ router.put('/:id', async (req, res) => {
     };
 
     const result = await Vote.updateOne(
-        { _id: id },
+        // do not update if this user has already voted
+        { _id: id, 'submissions.username': { $ne: sparcs_id } },
         { $push: { submissions: submission } }
     ).catch(error => {
         res.json({


### PR DESCRIPTION
This PR modifies the `GET /api/votes` and `PUT /api/votes` routes to block duplicate votes from happening.
`GET /api/votes` returns whether or not a user has voted to vote items or not.
`PUT /api/votes` blocks choices from pushing to the choices array.