### PR TITLE
feat(uid): identify users with uid

### DIFF
--- a/src/controllers/agenda.ts
+++ b/src/controllers/agenda.ts
@@ -15,7 +15,7 @@ export const getAgendas = async (
 
   const votes: VoteDocument[] = await Vote.find({
     agendaId: { $in: agendaIds },
-    username: req.decoded.sparcs_id,
+    uid: req.decoded.uid,
   });
 
   const agendasResponse = agendas.map(agenda => {

--- a/src/models/vote.ts
+++ b/src/models/vote.ts
@@ -3,7 +3,7 @@ import { MongoDocument } from '@/common/types';
 
 export interface BaseVote {
   agendaId: Document['_id'];
-  username: string;
+  uid: string;
   choice: string;
 }
 
@@ -15,7 +15,7 @@ const voteSchema = new Schema(
       type: Schema.Types.ObjectId,
       ref: 'Agenda',
     },
-    username: {
+    uid: {
       type: String,
       required: true,
     },

--- a/src/models/vote.ts
+++ b/src/models/vote.ts
@@ -4,6 +4,7 @@ import { MongoDocument } from '@/common/types';
 export interface BaseVote {
   agendaId: Document['_id'];
   uid: string;
+  username: string;
   choice: string;
 }
 
@@ -16,6 +17,10 @@ const voteSchema = new Schema(
       ref: 'Agenda',
     },
     uid: {
+      type: String,
+      required: true,
+    },
+    username: {
       type: String,
       required: true,
     },

--- a/src/socket/listeners/vote.ts
+++ b/src/socket/listeners/vote.ts
@@ -15,14 +15,14 @@ export const voteListener = (io: Server, socket: Socket): void => {
   socket.on(
     'agenda:vote',
     async (payload: AgendaVotePayload, callback: AdminCreateCallback) => {
-      const { username } = socket.request;
+      const { uid } = socket.request;
       const { agendaId, choice } = payload;
 
       const session = await startSession();
       try {
         session.startTransaction();
 
-        await Vote.create({ agendaId, username, choice });
+        await Vote.create({ agendaId, uid, choice });
 
         const agenda = await Agenda.findOne({ _id: agendaId });
         if (agenda === null || !agenda.votesCountMap.has(choice))

--- a/src/socket/listeners/vote.ts
+++ b/src/socket/listeners/vote.ts
@@ -15,14 +15,14 @@ export const voteListener = (io: Server, socket: Socket): void => {
   socket.on(
     'agenda:vote',
     async (payload: AgendaVotePayload, callback: AdminCreateCallback) => {
-      const { uid } = socket.request;
+      const { uid, username } = socket.request;
       const { agendaId, choice } = payload;
 
       const session = await startSession();
       try {
         session.startTransaction();
 
-        await Vote.create({ agendaId, uid, choice });
+        await Vote.create({ agendaId, uid, username, choice });
 
         const agenda = await Agenda.findOne({ _id: agendaId });
         if (agenda === null || !agenda.votesCountMap.has(choice))

--- a/src/socket/middlewares/auth.ts
+++ b/src/socket/middlewares/auth.ts
@@ -12,11 +12,12 @@ export const authMiddleware = (
   socket: Socket,
   next: (err?: Error) => void
 ): void => {
-  const { username, isAdmin } = getUserInformation(
+  const { username, isAdmin, uid } = getUserInformation(
     socket.handshake.query['token']
   );
 
   socket.request.username = username;
+  socket.request.uid = uid;
   socket.request.isAdmin = isAdmin;
 
   next();

--- a/src/socket/utils.ts
+++ b/src/socket/utils.ts
@@ -34,7 +34,11 @@ export const getUserInformation = (token: string): UserInfo => {
       process.env.TOKEN_SECRET as string
     ) as TokenPayload;
 
-    return { username: sparcs_id, uid, isAdmin };
+    // sparcs_id is null for SSO test accounts.
+    // in that case, assign a portion of uid to username
+    const username = sparcs_id ?? uid.slice(0, 10);
+
+    return { username, uid, isAdmin };
   } catch (err) {
     return {
       username: randomNames[Math.floor(Math.random() * randomNames.length)],

--- a/src/socket/utils.ts
+++ b/src/socket/utils.ts
@@ -14,6 +14,7 @@ const randomNames = [
 
 interface UserInfo {
   username: string;
+  uid: string;
   isAdmin: boolean;
 }
 
@@ -22,20 +23,22 @@ interface UserInfo {
  *  this function returns an object that has two keys:
  *  {
  *      username: user's nickname for chat. either SPARCS nickname or random
+ *      uid: uid(unique identification number) of user
  *      isAdmin: boolean value indicating whether this user is admin
  *  }
  */
 export const getUserInformation = (token: string): UserInfo => {
   try {
-    const { sparcs_id, isAdmin } = jwt.verify(
+    const { sparcs_id, uid, isAdmin } = jwt.verify(
       token,
       process.env.TOKEN_SECRET as string
     ) as TokenPayload;
 
-    return { username: sparcs_id, isAdmin };
+    return { username: sparcs_id, uid, isAdmin };
   } catch (err) {
     return {
       username: randomNames[Math.floor(Math.random() * randomNames.length)],
+      uid: 'mock-uid',
       isAdmin: false,
     };
   }


### PR DESCRIPTION
유저들을 `uid`로 구분하도록 수정하였습니다.

본래는 유저들을 `sparcs_id`라는 필드로 구분하고 있었는데 엄밀히 보면 가변적인 필드라 대신 `uid`로 구분하도록 변경하였습니다.

기존에 `sparcs_id`로 **구분**하고 있던 부분은 투표 쪽입니다. 따라서 투표 스키마를 일부 수정했습니다.