### PR TITLE
provide API for agenda participants and people who did not vote

### DIFF
--- a/src/controllers/agenda.ts
+++ b/src/controllers/agenda.ts
@@ -13,11 +13,11 @@ export const getAgendas = async (
 
   const agendaIds = agendas.map(({ _id }) => _id);
 
-  const votes: {
-    // eslint-disable-next-line
-    _id: any;
-    voters: { username: string; choice: string; uid: string }[];
-  }[] = await Vote.aggregate([
+  type Voter = { username: string; choice: string; uid: string };
+  // eslint-disable-next-line
+  type VoteAggregate = { _id: any; voters: Voter[] };
+
+  const votes: VoteAggregate[] = await Vote.aggregate([
     { $match: { agendaId: { $in: agendaIds } } },
     {
       $group: {

--- a/src/models/agenda.ts
+++ b/src/models/agenda.ts
@@ -11,6 +11,7 @@ export interface BaseAgenda {
   expires: Date;
   choices: string[];
   votesCountMap: Map<string, number>;
+  participants: string[];
 }
 
 export type AgendaDocument = MongoDocument<BaseAgenda>;
@@ -57,6 +58,10 @@ const agendaSchema = new Schema(
     votesCountMap: {
       type: Map,
       of: Number,
+      required: true,
+    },
+    participants: {
+      type: [String], // array of uids
       required: true,
     },
   },

--- a/src/socket/listeners/admin.ts
+++ b/src/socket/listeners/admin.ts
@@ -2,6 +2,7 @@ import { Server, Socket } from 'socket.io';
 import { SuccessStatusResponse } from '@/common/types';
 import { AgendaStatus } from '@/common/enums';
 import Agenda, { BaseAgenda } from '@/models/agenda';
+import { redis } from '@/database/redis-instance';
 
 type AdminCreatePayload = Pick<
   BaseAgenda,
@@ -25,6 +26,8 @@ export const adminListener = (io: Server, socket: Socket): void => {
   socket.on(
     'admin:create',
     async (payload: AdminCreatePayload, callback: AdminCreateCallback) => {
+      const redisClient = redis.getConnection();
+
       // payload has 4 fields. title, content, subtitle, choices
       const currentTime = Date.now();
       // agenda lasts for 3 hours. this value is arbitrary and temporary
@@ -32,10 +35,12 @@ export const adminListener = (io: Server, socket: Socket): void => {
 
       // all choices are initialized with a vote count of 0
       const votesCountMap = new Map(payload.choices.map(choice => [choice, 0]));
+      const participants = await redisClient.hkeys('accessors');
 
       const newAgenda = new Agenda({
         ...payload,
         votesCountMap,
+        participants,
         status: AgendaStatus.PREPARE,
         createDate: new Date(Date.now()),
         expires: new Date(currentTime + validDuration),


### PR DESCRIPTION
추가사항:
* `Agenda`(안건) 모델에 `participants` 필드 추가 - 해당 안건을 생성할 시 접속해 있던 사람들의 uid 배열로 구성해놓음
* `GET /api/agendas`에서
  * 현재까지 투표하지 않은 인원 목록 (`pplWhoDidNotVote`)
  * 안건에 참여한 인원 목록을 전달하도록 수정 (`participants`)

결론적으로 `/api/agendas` 의 응답은 다음과 같이 생겼습니다.
```javascript
[
  {
    _id: '6107ea51ee385f7b67e7a3e8',
    choices: [ '찬성', '반대' ],
    status: 'progress',
    participants: [ 'pacopaco', 'testebea0f' ],
    title: 'asdf',
    content: 'qwer',
    subtitle: 'bs',
    votesCountMap: { '찬성': 0, '반대': 1 },
    createDate: 2021-08-02T12:51:29.407Z,
    expires: 2021-08-02T12:51:38.434Z,
    __v: 0,
    pplWhoDidNotVote: [ 'pacopaco' ],
    userChoice: null
  },
  {
    _id: '6107e253b0b5a36bacf94ad4',
    choices: [ '찬성', '반대' ],
    status: 'progress',
    participants: [ 'pacopaco' ],
    title: 'foo',
    content: 'bar',
    subtitle: 'baz',
    votesCountMap: { '찬성': 1, '반대': 1 },
    createDate: 2021-08-02T12:17:23.044Z,
    expires: 2021-08-02T12:22:08.455Z,
    __v: 0,
    pplWhoDidNotVote: [],
    userChoice: '반대'
  },
  {
    _id: '6107e35cb0b5a36bacf94ad7',
    choices: [ '찬성', '반대' ],
    status: 'progress',
    participants: [ 'pacopaco', 'testebea0f' ],
    title: 'bar',
    content: 'baz',
    subtitle: 'fo',
    votesCountMap: { '찬성': 1, '반대': 0 },
    createDate: 2021-08-02T12:21:48.949Z,
    expires: 2021-08-02T12:22:07.893Z,
    __v: 0,
    pplWhoDidNotVote: [ 'testebea0f' ],
    userChoice: '찬성'
  }
]
```