### PR TITLE
feat(vote): added list of people who did not vote

### DIFF
--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -30,5 +30,6 @@ export type UserInfo = TokenPayload;
 
 export interface SuccessStatusResponse {
   success: boolean;
+  payload?: any;
   message?: string;
 }

--- a/src/socket/listeners/vote.ts
+++ b/src/socket/listeners/vote.ts
@@ -95,7 +95,7 @@ export const voteListener = (io: Server, socket: Socket): void => {
           },
         });
       } else {
-        callback({ success: false, message: 'No permission' });
+        callback({ success: false, payload: 'No permission' });
       }
     }
   );

--- a/src/socket/listeners/vote.ts
+++ b/src/socket/listeners/vote.ts
@@ -1,13 +1,17 @@
 import { Server, Socket } from 'socket.io';
 import { startSession } from 'mongoose';
 import { SuccessStatusResponse } from '@/common/types';
-import Agenda from '@/models/agenda';
+import Agenda, { AgendaDocument } from '@/models/agenda';
 import { AgendaStatus } from '@/common/enums';
 import Vote from '@/models/vote';
 
 interface AgendaVotePayload {
   agendaId: string;
   choice: string;
+}
+
+interface AgendaPPLPayload {
+  agendaId: string;
 }
 
 type AdminCreateCallback = (response: SuccessStatusResponse) => void;
@@ -20,12 +24,12 @@ export const voteListener = (io: Server, socket: Socket): void => {
       const { agendaId, choice } = payload;
 
       const session = await startSession();
+      const agenda = await Agenda.findOne({ _id: agendaId });
       try {
         session.startTransaction();
 
         await Vote.create({ agendaId, uid, username, choice });
 
-        const agenda = await Agenda.findOne({ _id: agendaId });
         if (
           agenda === null ||
           !agenda.votesCountMap.has(choice) ||
@@ -53,7 +57,46 @@ export const voteListener = (io: Server, socket: Socket): void => {
         return;
       }
 
+      io.emit('agenda:voted', {
+        agendaId,
+      });
+
       callback({ success: true });
+    }
+  );
+  socket.on(
+    'agenda:status',
+    async (payload: AgendaPPLPayload, callback: AdminCreateCallback) => {
+      const { isAdmin } = socket.user;
+      const { agendaId } = payload;
+      const agenda = await Agenda.findOne({ _id: agendaId });
+      if (agenda === null) {
+        callback({ success: false, payload: 'Agenda not found' });
+        return;
+      }
+
+      if (isAdmin) {
+        const { participants } = agenda;
+
+        const voteInfo = await Vote.find({ agendaId: agenda._id });
+        const voterNames = voteInfo.map(({ username }) => username);
+
+        const pplWhoDidNotVote = participants.filter(
+          name => !voterNames.includes(name)
+        );
+
+        callback({
+          success: true,
+          payload: {
+            pplWhoDidNotVote,
+            agendaId,
+            agendaTitle: agenda.title,
+            isExpired: agenda.checkStatus() === AgendaStatus.TERMINATE,
+          },
+        });
+      } else {
+        callback({ success: false, message: 'No permission' });
+      }
     }
   );
 };


### PR DESCRIPTION
### 목표

- **admin한테만** 안 투표한 사람을 보여주는 방법이 없을까?
    
    

### 구현

백엔드 authListener의 토큰 조회에서 admin인지 아닌지 조회 가능 → 클라이언트의 소켓 정보를 조회해서 admin이라면 투표하지 않은 사람 목록 및 아젠다 정보를 payload로 반환해주고, 아닐 경우 no permisson 메세지 반환

### 기타 설명

- voteListener의 agenda:vote event listener 콜백함수 리팩토링
- biseo-frontend/src/common/types.ts > Agenda의 경우 pplWhoDidNotVote가 사용되는 부분이 없음에도 존재함 → 삭제
    - admin의 경우에도 이 정보를 Agenda 객체로 받는 것이 아니라 별도의 payload로 받기 때문에, 앞으로 사용될 일도 없음

### 새로운 문제점

- ~~SuccessStatusResponse의 payload를 any 타입으로 했는데, 더 구체적인 타입으로 바꾸어야 함~~
	-> payload와 message를 union type으로 합쳐 새로운 타입 payload를 정의함
- 현재로써는 admin이 투표 안 한 사람을 보려면 /main으로 이동한 후 콘솔 창을 보고 있어야하는데, 다른 화면을 보고 있을 때도 알 수 있다면 좋을 듯
    
    ![Screen Shot 2021-11-07 at 9.07.06 PM.png](https://s3.us-west-2.amazonaws.com/secure.notion-static.com/e769aea5-5fc9-452a-951d-fecf007e0e09/Screen_Shot_2021-11-07_at_9.07.06_PM.png?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAT73L2G45O3KS52Y5%2F20211107%2Fus-west-2%2Fs3%2Faws4_request&X-Amz-Date=20211107T122612Z&X-Amz-Expires=86400&X-Amz-Signature=ad4caf788004ab96a44b17b0b75b23f732449ecd34784f0f67924bbf1f293a4b&X-Amz-SignedHeaders=host&response-content-disposition=filename%20%3D%22Screen%2520Shot%25202021-11-07%2520at%25209.07.06%2520PM.png%22)
    
- 투표 종료 시 agenda:status의 콜백이 출력하는 정보가 바로 업데이트 되지 않음