### PR TITLE
feat(chat): online user list in chat

### DIFF
--- a/src/socket/index.ts
+++ b/src/socket/index.ts
@@ -7,7 +7,6 @@ import {
   voteListener,
 } from './listeners';
 import { authMiddleware } from './middlewares';
-import { getConnectedMembers } from './utils';
 import { redis } from '@/database/redis-instance';
 import { MemberState } from '@/common/enums';
 import User, { UserDocument } from '@/models/user';
@@ -55,11 +54,6 @@ export default (httpServer: http.Server): void => {
         isVotable: [false, false, false],
       });
     }
-
-    const members = await getConnectedMembers();
-    socket.emit('chat:members', members); // send list of members to new user
-
-    socket.emit('chat:name', sparcs_id); // send sparcs_id to new user
 
     // listen for chats
     chatListener(io, socket);

--- a/src/socket/listeners/disconnect.ts
+++ b/src/socket/listeners/disconnect.ts
@@ -1,5 +1,4 @@
 import { Server, Socket } from 'socket.io';
-import { getConnectedMembers } from '@/socket/utils';
 import { redis } from '@/database/redis-instance';
 
 /*
@@ -31,9 +30,7 @@ export const disconnectListener = (
         // no need to broadcast. user is still here
         return;
 
-      const members = await getConnectedMembers();
       await redisClient.hdel('memberStates', uid); // 해당 유저를 memberStates에서 아예 삭제
-      socket.broadcast.emit('chat:members', members); // 접속자가 변경되었으므로 전체 유저에게 변경된 접속자를 보내줌
       socket.broadcast.emit('chat:out', sparcs_id); // 전체 유저에게 누가 나갔는지 보내줌
     } catch (error) {
       console.error(error);

--- a/src/socket/utils.ts
+++ b/src/socket/utils.ts
@@ -31,7 +31,7 @@ export const getConnectedMembers = async (): Promise<string[]> => {
 };
 
 /*
- * getOnlineMembers - get online or vacant member names that are currently connected to the server socket and online.
+ * getOnlineVacantMembers - get online or vacant member names that are currently connected to the server socket and online.
  *  this function returns an array of strings
  */
 export const getOnlineVacantMembers = async (): Promise<


### PR DESCRIPTION
## 주요 변경 사항
- 채팅 실시간 유저 목록을 보내주는 chat > socket api를 다듬었습니다.
- `'chat:members'`를 소켓 연결시 바로 보내주는데, client 입장에서 첫 접속할 때는 잘 작동이 되나, 새로고침할 때는 client에서 잘 받아오지 못하여 client측에서 `emit('chat:members')`를 해주면 해당 정보를 `emit`하는 형식으로 변경해주었습니다.
- `'chat:members'`는 기존에 처음 접속했을 때는 uid를, 유저가 disconnect되었을 때는 sparcsId를 보내주었습니다. 일관성있고, client에서 처리하기 용이하고자 `sparcsId`로 통일하였습니다.
- `'chat:members`'의 데이터 타입을 유저의 상태(온라인 or 자리비움)를 보내주기 위해 `string`에서 `{ sparcsId: string, state: MemberState }`로 변경하였습니다.
- `'chat:name'`은 client에서 redux store을 이용하여 불러오도록 하여 삭제했습니다.