### PR TITLE
feat(edit-agenda): edit participants

### DIFF
--- a/src/socket/listeners/admin.ts
+++ b/src/socket/listeners/admin.ts
@@ -113,6 +113,7 @@ export const adminListener = (
         choices,
         createDate,
         votesCountMap,
+        participants,
       } = result;
 
       emitParticipantsAndAdmin(
@@ -131,6 +132,7 @@ export const adminListener = (
           expires,
           createDate,
           votesCountMap,
+          participants,
         }
       );
 
@@ -170,6 +172,7 @@ export const adminListener = (
         choices,
         createDate,
         votesCountMap,
+        participants,
       } = result;
 
       emitParticipantsAndAdmin(
@@ -188,6 +191,7 @@ export const adminListener = (
           expires,
           createDate,
           votesCountMap,
+          participants,
         }
       );
 

--- a/src/socket/listeners/admin.ts
+++ b/src/socket/listeners/admin.ts
@@ -63,6 +63,7 @@ export const adminListener = (
         status,
         expires,
         choices,
+        participants,
       } = result;
 
       emitAdmin(adminSocketIds, io, 'agenda:created', {
@@ -73,6 +74,7 @@ export const adminListener = (
         choices,
         status,
         expires,
+        participants,
       });
 
       callback({ success: true });
@@ -211,6 +213,7 @@ export const adminListener = (
       agenda.content = payload.content;
       agenda.subtitle = payload.subtitle;
       agenda.choices = payload.choices;
+      agenda.participants = payload.participants;
 
       const result = await agenda.save().catch(error => {
         console.error('Error while starting agenda');
@@ -232,6 +235,7 @@ export const adminListener = (
         choices,
         createDate,
         votesCountMap,
+        participants,
       } = result;
 
       emitParticipantsAndAdmin(
@@ -250,6 +254,7 @@ export const adminListener = (
           expires,
           createDate,
           votesCountMap,
+          participants,
         }
       );
 


### PR DESCRIPTION
###'admin:create'와 'admin:edit'에서 agenda를 return할 때 participants 정보도 포함합니다.
- agenda 생성, 수정시 설정한 투표 대상이 바로 반영됩니다.